### PR TITLE
Bot should not handle messages originating from itself

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -176,6 +176,12 @@ func (a *BotAdapter) handleSlackEvents(brain *joe.Brain) {
 }
 
 func (a *BotAdapter) handleMessageEvent(ev *slack.MessageEvent, brain *joe.Brain) {
+	// check if the message comes from ourselves
+	if ev.User == a.userID {
+		// msg is from us, ignore it!
+		return
+	}
+
 	// check if we have a DM, or standard channel post
 	selfLink := a.userLink(a.userID)
 	direct := strings.HasPrefix(ev.Msg.Channel, "D")

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -15,20 +15,15 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-var (
-	// compile time test to check if we are implementing the interface.
-	_ joe.Adapter = new(BotAdapter)
-
-	botUser   = "test-bot"
-	botUserID = "42"
-)
+// compile time test to check if we are implementing the interface.
+var _ joe.Adapter = new(BotAdapter)
 
 func newTestAdapter(t *testing.T) (*BotAdapter, *mockSlack) {
 	ctx := context.Background()
 	logger := zaptest.NewLogger(t)
 	client := new(mockSlack)
 
-	authTestResp := &slack.AuthTestResponse{User: botUser, UserID: botUserID}
+	authTestResp := &slack.AuthTestResponse{User: "test-bot", UserID: "42"}
 	client.On("AuthTestContext", ctx).Return(authTestResp, nil)
 
 	conf := Config{Logger: logger}
@@ -77,7 +72,7 @@ func TestAdapter_IgnoreChannelOwnMessages(t *testing.T) {
 		Msg: slack.Msg{
 			Text:    "Hello world",
 			Channel: "C1H9RESGL",
-			User:    botUserID,
+			User:    "42",
 		},
 	}
 
@@ -133,7 +128,7 @@ func TestAdapter_IgnoreDirectOwnMessages(t *testing.T) {
 		Msg: slack.Msg{
 			Text:    "Hello world",
 			Channel: "D023BB3L2",
-			User:    botUserID,
+			User:    "42",
 		},
 	}
 

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -63,6 +63,33 @@ func TestAdapter_IgnoreNormalMessages(t *testing.T) {
 	assert.Empty(t, brain.RecordedEvents())
 }
 
+func TestAdapter_IgnoreChannelOwnMessages(t *testing.T) {
+	brain := joetest.NewBrain(t)
+	a, _ := newTestAdapter(t)
+
+	done := make(chan bool)
+	go func() {
+		a.handleSlackEvents(brain.Brain)
+		done <- true
+	}()
+
+	evt := &slack.MessageEvent{
+		Msg: slack.Msg{
+			Text:    "Hello world",
+			Channel: "C1H9RESGL",
+			User:    botUserID,
+		},
+	}
+
+	a.events <- slack.RTMEvent{Data: evt}
+
+	close(a.events)
+	<-done
+	brain.Finish()
+
+	assert.Empty(t, brain.RecordedEvents())
+}
+
 func TestAdapter_DirectMessages(t *testing.T) {
 	brain := joetest.NewBrain(t)
 	a, _ := newTestAdapter(t)


### PR DESCRIPTION
This attempts to fix #5. 

The approach is a bit naive but it seems to work in my own testing as well as the included test cases 

This adds a check that skips message event handling if the message came from the bot user.

I cannot think of a reason the bot would want to handle it's own messages.
