### PR TITLE
Update adapter.go

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -313,6 +313,23 @@ func (a *BotAdapter) Send(text, channelID string) error {
 	return err
 }
 
+func (a *BotAdapter) SendWithSlackOpts(text, channelID string, inOpts ...slack.MsgOption) error {
+	a.logger.Info("Sending message to channel",
+		zap.String("channel_id", channelID),
+		// do not leak actual message content since it might be sensitive
+	)
+
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(text, false),
+		slack.MsgOptionPostMessageParameters(a.sendMsgParams),
+		slack.MsgOptionUser(a.userID),
+		slack.MsgOptionUsername(a.name),
+	}
+	opts = append(opts, inOpts...)
+	_, _, err := a.slack.PostMessageContext(a.context, channelID, opts...)
+	return err
+}
+
 // React implements joe.ReactionAwareAdapter by letting the bot attach the given
 // reaction to the message.
 func (a *BotAdapter) React(reaction reactions.Reaction, msg joe.Message) error {


### PR DESCRIPTION
First of all: I really like your joe-bot and the adapters that come with it.
Thanks for your great work!

However, I ran into a bit of a problem currently with the slack-adapter:
In one of my projects I use your slack adapter inside a custom joe-bot adapter. 
This custom joe-bot adapter several custom send methods which used to use the Send()-method of your slack-adapter.

Since I now want to additionally send slack-blocks, when sending messages to slack, I need to be able to hand over a slack blocks message option to the slack API. However this is currently not possible, because the slack API is hidden inside your slack BotAdapter. But with offering a `SendWithSlackOpts(...)`-method, this could become easily available.

What I used to do:
```go
func (a *slackAdapter) broadcastSend(text, channel string) error {
	return a.eventsAPIServer.Send(text, channel)
}
```

What I would like to do:
```go
func (a *slackAdapter) privateSend(parsed parsedText, channel string) error {
	blocks, err := a.getSlackBlocks(parsed)
	if err != nil {
		return fmt.Errorf("could not get slack blocks: %w", err)
	}
	opt := slack.MsgOptionBlocks(blocks...)
	return a.eventsAPIServer.SendWithSlackOpts(parsed.text, channel, opt)
}
```

I wonder whether It would be possible to offer such a `SendWithSlackOpts(...)`-method? 
Or is there anything speaking against it?